### PR TITLE
Adding timeout parameter

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,9 +44,6 @@ pub struct PTouch {
 /// Brother USB Vendor ID
 pub const BROTHER_VID: u16 = 0x04F9;
 
-/// Default USB timeout
-pub const DEFAULT_TIMEOUT: Duration = Duration::from_millis(500);
-
 /// Options for connecting to a PTouch device
 #[derive(Clone, PartialEq, Debug)]
 #[cfg_attr(feature = "structopt", derive(StructOpt))]
@@ -58,6 +55,10 @@ pub struct Options {
     #[cfg_attr(feature = "structopt", structopt(long, default_value = "0"))]
     /// Index (if multiple devices are connected)
     pub index: usize,
+
+    #[cfg_attr(feature = "structopt", structopt(long, default_value = "500"))]
+    /// Index (if multiple devices are connected)
+    pub timeout_milliseconds: u64,
 
     #[cfg_attr(feature = "structopt", structopt(long, hidden = true))]
     /// Do not reset the device on connect
@@ -277,7 +278,7 @@ impl PTouch {
             descriptor,
             cmd_ep,
             stat_ep,
-            timeout: DEFAULT_TIMEOUT,
+            timeout: Duration::from_millis(o.timeout_milliseconds),
         };
 
         // Unless we're skipping reset

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,7 +57,7 @@ pub struct Options {
     pub index: usize,
 
     #[cfg_attr(feature = "structopt", structopt(long, default_value = "500"))]
-    /// Index (if multiple devices are connected)
+    /// Timeout to pass to the read_bulk and write_bulk methods
     pub timeout_milliseconds: u64,
 
     #[cfg_attr(feature = "structopt", structopt(long, hidden = true))]


### PR DESCRIPTION
The possibility for the user to change the timeout for USB read and write without editing the code would be nice.

Until now, the timeout was defined through a const called `DEFAULT_TIMEOUT`.
I added a field to the `Options` struct in the lib.rs file, called `timeout_milliseconds`, of type `u64` and default value `500`. With an appropriate `#[cfg_attr(...)]` above its declaration, the user can change its value when running the program, by adding `--timeout-milliseconds <desired timeout>` to the command.
The `timeout_milliseconds` field is used in lib.rs, when instanciating a `PTouch` struct: its `timeout` field is set to a `Duration` object called with `Duration::from_millis(o.timeout_milliseconds)` (`o` is the instance of the `Options` struct used in this context).

Note that I am a Rust beginner ; though this change is very simple, There might be something that I could have done better/cleaner. Please tell me if it is the case.