### PR TITLE
Adding no status check parameter

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,7 +25,7 @@ jobs:
             output: ptouch-util
             args: --no-default-features --features=util
           - target: armv7-unknown-linux-gnueabihf 
-            os: ubuntu-20.04
+            os: ubuntu-latest
             output: ptouch-util
             apt-arch: armhf
           - target: x86_64-apple-darwin
@@ -70,7 +70,7 @@ jobs:
       uses: ryankurte/action-apt@v0.3.0
       with:
         arch: ${{ matrix.apt-arch }}
-        packages: libusb-dev:${{ matrix.apt-arch }} libsdl2-dev:${{ matrix.apt-arch }}
+        packages: libusb-dev:${{ matrix.apt-arch }} libusb-1.0-0-dev:${{ matrix.apt-arch }} libsdl2-dev:${{ matrix.apt-arch }}
 
     - name: Install cross toolchain (armv7)
       if: ${{ matrix.target == 'armv7-unknown-linux-gnueabihf' }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -63,7 +63,7 @@ jobs:
     
     - name: Install deps (apt native)
       if: ${{ matrix.os == 'ubuntu-latest' && matrix.target == 'x86_64-unknown-linux-gnu' }}
-      run: sudo apt install -y libusb-dev
+      run: sudo apt install -y libusb-dev libusb-1.0-0-dev
 
     - name: Install deps (foreign architecture)
       if: ${{ matrix.apt-arch }}

--- a/src/device.rs
+++ b/src/device.rs
@@ -4,6 +4,8 @@
 // https://github.com/ryankurte/rust-ptouch
 // Copyright 2021 Ryan Kurte
 
+use crate::Error;
+
 use bitflags::bitflags;
 
 #[cfg(feature = "strum")]
@@ -381,6 +383,27 @@ pub struct Status {
 
     pub tape_colour: TapeColour,
     pub text_colour: TextColour,
+}
+
+impl Status {
+    // This function is gonna be called if the --no-status-fetch flag is enabled.
+    // It returns a default status, which is assumed to be correct to then print.
+    pub fn new(media: &Media) -> Result<Status, Error> {
+        Ok(Status {
+            model: 0,                                   // The model is not that important, and also the manual only shows the model ID of E550W and E750W
+            error1: Error1::empty(),                    // Assuming there's no error
+            error2: Error2::empty(),                    // Assuming there's no error
+            media_width: media.width() as u8,           // Width given by user in command
+            media_kind: match media.is_tape() {         // Not sure if this is really important, but this is an easy way to detect if it is tape (can't know if laminated or not) or not
+                true => MediaKind::LaminatedTape,
+                false => MediaKind::HeatShrinkTube
+            },
+            status_type: DeviceStatus::Completed,       // Assuming the printer is ready to print
+            phase: Phase::Editing,                      // Assuming the printer is not printing
+            tape_colour: TapeColour::White,             // By default, assuming the tape is white...
+            text_colour: TextColour::Black,             // ...and the text colour is black. Would maybe be good to let the user change it in the command
+        })
+    }
 }
 
 impl From<[u8; 32]> for Status {

--- a/src/device.rs
+++ b/src/device.rs
@@ -135,9 +135,9 @@ impl Media {
         match self {
             Tze6mm => 6,
             Tze9mm => 9,
-            Tze12mm => 2,
-            Tze18mm => 8,
-            Tze24mm => 4,
+            Tze12mm => 12,
+            Tze18mm => 18,
+            Tze24mm => 24,
             Hs6mm => 6,
             Hs9mm => 9,
             Hs12mm => 12,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,6 +70,10 @@ pub struct Options {
     #[cfg_attr(feature = "structopt", structopt(long, hidden = true))]
     /// (DEBUG) Do not detach from kernel drivers on connect
     pub usb_no_detach: bool,
+
+    #[structopt(long)]
+    /// If true, the program will not perform a status request
+    pub no_status_fetch: bool,
 }
 
 // Lazy initialised libusb context

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -344,6 +344,25 @@ impl PTouch {
         Ok(s)
     }
 
+    // This function is gonna be called if the --no-status-fetch flag is enabled.
+    // It returns a default status, which is assumed to be correct to then print.
+    pub fn status_default(&mut self, media: &Media) -> Result<Status, Error> {
+        Ok(Status {
+            model: 0,                               // The model is not that important, and also the manual only shows the model ID of E550W and E750W
+            error1: Error1::empty(),                // Assuming there's no error
+            error2: Error2::empty(),                // Assuming there's no error
+            media_width: media.width() as u8,             // Width given by user in command
+            media_kind: match media.is_tape() {     // Not sure if this is really important, but this is an easy way to detect if it is tape (can't know if laminated or not) or not
+                true => MediaKind::LaminatedTape,
+                false => MediaKind::HeatShrinkTube
+            },
+            status_type: DeviceStatus::Completed,   // Assuming the printer is ready to print
+            phase: Phase::Editing,                  // Assuming the printer is not printing
+            tape_colour: TapeColour::White,         // By default, assuming the tape is white...
+            text_colour: TextColour::Black,         // ...and the text colour is black. Would maybe be good to let the user change it in the command
+        })
+    }
+
     /// Setup the printer and print using raw raster data.
     /// Print output must be shifted and in the correct bit-order for this function.
     /// 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -348,25 +348,6 @@ impl PTouch {
         Ok(s)
     }
 
-    // This function is gonna be called if the --no-status-fetch flag is enabled.
-    // It returns a default status, which is assumed to be correct to then print.
-    pub fn status_default(&mut self, media: &Media) -> Result<Status, Error> {
-        Ok(Status {
-            model: 0,                               // The model is not that important, and also the manual only shows the model ID of E550W and E750W
-            error1: Error1::empty(),                // Assuming there's no error
-            error2: Error2::empty(),                // Assuming there's no error
-            media_width: media.width() as u8,             // Width given by user in command
-            media_kind: match media.is_tape() {     // Not sure if this is really important, but this is an easy way to detect if it is tape (can't know if laminated or not) or not
-                true => MediaKind::LaminatedTape,
-                false => MediaKind::HeatShrinkTube
-            },
-            status_type: DeviceStatus::Completed,   // Assuming the printer is ready to print
-            phase: Phase::Editing,                  // Assuming the printer is not printing
-            tape_colour: TapeColour::White,         // By default, assuming the tape is white...
-            text_colour: TextColour::Black,         // ...and the text colour is black. Would maybe be good to let the user change it in the command
-        })
-    }
-
     /// Setup the printer and print using raw raster data.
     /// Print output must be shifted and in the correct bit-order for this function.
     /// 

--- a/src/util.rs
+++ b/src/util.rs
@@ -25,10 +25,6 @@ pub struct Flags {
     /// Padding for start and end of renders
     pad: usize,
 
-    #[structopt(long)]
-    /// If true, the program will not perform a status request
-    no_status_fetch: bool,
-
     #[structopt(long, possible_values = &Media::VARIANTS, default_value="tze12mm")]
     /// Default media kind when unable to query this from printer
     media: Media,
@@ -132,7 +128,7 @@ fn main() -> anyhow::Result<()> {
     let connect = match PTouch::new(&opts.options) {
         Ok(mut pt) => {
             let status;
-            if opts.no_status_fetch {
+            if opts.options.no_status_fetch {
                 debug!("Connected! status request disabled, using default status...");
                 // Getting default status
                 status = pt.status_default(&opts.media)?;

--- a/src/util.rs
+++ b/src/util.rs
@@ -3,7 +3,7 @@
 // https://github.com/ryankurte/rust-ptouch
 // Copyright 2021 Ryan Kurte
 
-use log::{debug, warn};
+use log::{debug, info, warn};
 use simplelog::{LevelFilter, TermLogger, TerminalMode};
 use structopt::StructOpt;
 use strum::VariantNames;
@@ -129,11 +129,11 @@ fn main() -> anyhow::Result<()> {
         Ok(mut pt) => {
             let status;
             if opts.options.no_status_fetch {
-                debug!("Connected! status request disabled, using default status...");
+                info!("Connected! status request disabled, using default status...");
                 // Getting default status
                 status = Status::new(&opts.media)?;
             } else {
-                debug!("Connected! fetching status...");
+                info!("Connected! fetching status...");
                 // Fetch device status
                 status = pt.status()?;
             }

--- a/src/util.rs
+++ b/src/util.rs
@@ -9,7 +9,7 @@ use structopt::StructOpt;
 use strum::VariantNames;
 
 use ptouch::{Options, PTouch, render::RenderTemplate};
-use ptouch::device::{Media, PrintInfo};
+use ptouch::device::{Media, PrintInfo, Status};
 use ptouch::render::{FontKind, Op, Render, RenderConfig};
 
 
@@ -131,7 +131,7 @@ fn main() -> anyhow::Result<()> {
             if opts.options.no_status_fetch {
                 debug!("Connected! status request disabled, using default status...");
                 // Getting default status
-                status = pt.status_default(&opts.media)?;
+                status = Status::new(&opts.media)?;
             } else {
                 debug!("Connected! fetching status...");
                 // Fetch device status

--- a/src/util.rs
+++ b/src/util.rs
@@ -132,13 +132,13 @@ fn main() -> anyhow::Result<()> {
                 info!("Connected! status request disabled, using default status...");
                 // Getting default status
                 status = Status::new(&opts.media)?;
+                info!("Device status (default one used): {:?}", status);
             } else {
                 info!("Connected! fetching status...");
                 // Fetch device status
                 status = pt.status()?;
+                info!("Device status (fetched from device): {:?}", status);
             }
-
-            debug!("Device status: {:?}", status);
 
             // Build MediaWidth from status message to retrieve offsets
             let media = Media::from((status.media_kind, status.media_width));


### PR DESCRIPTION
Hi,

The idea you suggested [here](https://github.com/ryankurte/rust-ptouch/issues/31#issuecomment-1190803541), which is to add a flag to not fetch the printer status, is great, and I tried implementing it. 
i am still not able to print normally (still the same bug described in #31), but adding the `--no-status-fetch` flag to the command, the command works and I am able to print without any issue.

To implement it, I added a [status_default method](https://github.com/Natsukooh/rust-ptouch/blob/2af4d6f87c7f830696d2c1e7eef6133955ae6046/src/lib.rs#L353) to mock the actual status. 
The part of the code that previously called the `status` method now checks if the flag is enabled, and if it is, calls the `status_default` method instead:
```rust
let status;
if opts.options.no_status_fetch {
    debug!("Connected! status request disabled, using default status...");
    // Getting default status
    status = pt.status_default(&opts.media)?;
} else {
    debug!("Connected! fetching status...");
    // Fetch device status
    status = pt.status()?;
}
```

The flag is located in the `Options` struct, and an instance of it is inside the `Flags` struct.
I first put it in the `Flags` struct, but because some options related to the connection with the printer such as `--usb-no-detach` or `--usb-no-claim` were located inside `Options`, I moved my flag inside it.

Also, to build the default `Status` struct, I used the `width` method of the `Media` struct, to get the correct tape width (note that since the width is normally given by the status, the user has to provide the correct one with the `--media <tape size>` switch). But I noticed a bug in the method, which I described in a new issue: #33. It was very easy to fix, and necessary to be able to print normally.

Let me know if I have done things wrong (I've never contributed to open source projects before, so there may be some conventions I'm doing wrong 😅) !